### PR TITLE
Move Display Settings to Tab and Limit Options by OS

### DIFF
--- a/Menus/settings_menu.gd
+++ b/Menus/settings_menu.gd
@@ -14,12 +14,20 @@ signal language_changed(language: String)
 @onready var close_button:Button = %CloseButton as Button
 @onready var save_button:Button = %SaveButton as Button
 @onready var quit_button:Button = %QuitButton as Button
+@onready var settings_tabs:TabContainer = %SettingsTabs
 @onready var SFX_BUS_ID = AudioServer.get_bus_index("SFX")
 @onready var MUSIC_BUS_ID = AudioServer.get_bus_index("Music")
 
 var user_prefs:UserPrefs
 
 func _ready():
+	if OS.get_name() in ["Web", "iOS", "Android"]:
+		# Display settings don't work for Web and Mobile
+		settings_tabs.set_tab_disabled(1, true)
+	elif OS.get_name() == "macOS":
+		# MacOS borderless fullscreen behaves the same as fullscreen
+		window_mode_dropdown.remove_item(2)
+	
 	for res in DisplayManager.window_resolutions:
 		window_resolution_dropdown.add_item("%dx%d" % [res.x, res.y])
 	

--- a/Menus/settings_menu.tscn
+++ b/Menus/settings_menu.tscn
@@ -69,26 +69,92 @@ theme_override_font_sizes/font_size = 32
 text = "Settings"
 horizontal_alignment = 1
 
-[node name="MarginContainer" type="MarginContainer" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer"]
+[node name="SettingsTabs" type="TabContainer" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="Gameplay" type="MarginContainer" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs"]
 layout_mode = 2
 theme_override_constants/margin_left = 25
 theme_override_constants/margin_top = 25
 theme_override_constants/margin_right = 25
 theme_override_constants/margin_bottom = 25
 
-[node name="GridContainer" type="GridContainer" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/MarginContainer"]
+[node name="GridContainer" type="GridContainer" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs/Gameplay"]
 layout_mode = 2
 columns = 2
 
-[node name="WindowMode" type="Label" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/MarginContainer/GridContainer"]
+[node name="MusicVol" type="Label" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs/Gameplay/GridContainer"]
 custom_minimum_size = Vector2(175, 0)
 layout_mode = 2
+text = "Music Volume"
+
+[node name="MusicSlider" type="HSlider" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs/Gameplay/GridContainer"]
+unique_name_in_owner = true
+layout_direction = 2
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 1
+size_flags_stretch_ratio = 2.0
+max_value = 1.0
+step = 0.05
+value = 1.0
+
+[node name="SFXVol" type="Label" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs/Gameplay/GridContainer"]
+custom_minimum_size = Vector2(175, 0)
+layout_mode = 2
+text = "SFX Volume"
+
+[node name="SFXSlider" type="HSlider" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs/Gameplay/GridContainer"]
+unique_name_in_owner = true
+layout_direction = 2
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 1
+size_flags_stretch_ratio = 2.0
+max_value = 1.0
+step = 0.05
+value = 1.0
+
+[node name="Language" type="Label" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs/Gameplay/GridContainer"]
+custom_minimum_size = Vector2(175, 0)
+layout_mode = 2
+text = "Language
+"
+
+[node name="LanguageDropdown" type="OptionButton" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs/Gameplay/GridContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+item_count = 2
+selected = 0
+popup/item_0/text = "English"
+popup/item_0/id = 0
+popup/item_1/text = "Spanish (Latin America)"
+popup/item_1/id = 1
+
+[node name="Display" type="MarginContainer" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs"]
+visible = false
+layout_mode = 2
+theme_override_constants/margin_left = 25
+theme_override_constants/margin_top = 25
+theme_override_constants/margin_right = 25
+theme_override_constants/margin_bottom = 25
+
+[node name="GridContainer" type="GridContainer" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs/Display"]
+layout_mode = 2
+columns = 2
+
+[node name="WindowMode" type="Label" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs/Display/GridContainer"]
+custom_minimum_size = Vector2(175, 0)
+layout_mode = 2
+size_flags_horizontal = 3
 text = "Window Mode
 "
 
-[node name="WindowModeDropdown" type="OptionButton" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/MarginContainer/GridContainer"]
+[node name="WindowModeDropdown" type="OptionButton" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs/Display/GridContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+size_flags_horizontal = 3
 item_count = 3
 selected = 0
 popup/item_0/text = "Windowed"
@@ -98,72 +164,28 @@ popup/item_1/id = 1
 popup/item_2/text = "Borderless Window"
 popup/item_2/id = 2
 
-[node name="WindowResolution" type="Label" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/MarginContainer/GridContainer"]
+[node name="WindowResolution" type="Label" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs/Display/GridContainer"]
 custom_minimum_size = Vector2(175, 0)
 layout_mode = 2
+size_flags_horizontal = 3
 text = "Window Resolution"
 
-[node name="WindowResolutionDropdown" type="OptionButton" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/MarginContainer/GridContainer"]
+[node name="WindowResolutionDropdown" type="OptionButton" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs/Display/GridContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+size_flags_horizontal = 3
 
-[node name="Monitor" type="Label" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/MarginContainer/GridContainer"]
+[node name="Monitor" type="Label" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs/Display/GridContainer"]
 custom_minimum_size = Vector2(175, 0)
 layout_mode = 2
+size_flags_horizontal = 3
 text = "Monitor
 "
 
-[node name="MonitorDropdown" type="OptionButton" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/MarginContainer/GridContainer"]
+[node name="MonitorDropdown" type="OptionButton" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs/Display/GridContainer"]
 unique_name_in_owner = true
-layout_mode = 2
-
-[node name="MusicVol" type="Label" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/MarginContainer/GridContainer"]
-custom_minimum_size = Vector2(175, 0)
-layout_mode = 2
-text = "Music Volume"
-
-[node name="MusicSlider" type="HSlider" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/MarginContainer/GridContainer"]
-unique_name_in_owner = true
-layout_direction = 2
 layout_mode = 2
 size_flags_horizontal = 3
-size_flags_vertical = 1
-size_flags_stretch_ratio = 2.0
-max_value = 1.0
-step = 0.05
-value = 1.0
-
-[node name="SFXVol" type="Label" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/MarginContainer/GridContainer"]
-custom_minimum_size = Vector2(175, 0)
-layout_mode = 2
-text = "SFX Volume"
-
-[node name="SFXSlider" type="HSlider" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/MarginContainer/GridContainer"]
-unique_name_in_owner = true
-layout_direction = 2
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 1
-size_flags_stretch_ratio = 2.0
-max_value = 1.0
-step = 0.05
-value = 1.0
-
-[node name="Language" type="Label" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/MarginContainer/GridContainer"]
-custom_minimum_size = Vector2(175, 0)
-layout_mode = 2
-text = "Language
-"
-
-[node name="LanguageDropdown" type="OptionButton" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer/MarginContainer/GridContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-item_count = 2
-selected = 0
-popup/item_0/text = "English"
-popup/item_0/id = 0
-popup/item_1/text = "Spanish (Latin America)"
-popup/item_1/id = 1
 
 [node name="Panel" type="Panel" parent="Panel/BackgroundPanel/MarginContainer/VBoxContainer"]
 custom_minimum_size = Vector2(2.08165e-12, 25)
@@ -198,12 +220,12 @@ size_flags_horizontal = 4
 size_flags_vertical = 8
 text = "Quit"
 
-[connection signal="item_selected" from="Panel/BackgroundPanel/MarginContainer/VBoxContainer/MarginContainer/GridContainer/WindowModeDropdown" to="." method="_on_window_mode_option_selected"]
-[connection signal="item_selected" from="Panel/BackgroundPanel/MarginContainer/VBoxContainer/MarginContainer/GridContainer/WindowResolutionDropdown" to="." method="_on_window_resolution_option_selected"]
-[connection signal="item_selected" from="Panel/BackgroundPanel/MarginContainer/VBoxContainer/MarginContainer/GridContainer/MonitorDropdown" to="." method="_on_monitor_option_selected"]
-[connection signal="value_changed" from="Panel/BackgroundPanel/MarginContainer/VBoxContainer/MarginContainer/GridContainer/MusicSlider" to="." method="_on_music_slider_value_changed"]
-[connection signal="value_changed" from="Panel/BackgroundPanel/MarginContainer/VBoxContainer/MarginContainer/GridContainer/SFXSlider" to="." method="_on_sfx_slider_value_changed"]
-[connection signal="item_selected" from="Panel/BackgroundPanel/MarginContainer/VBoxContainer/MarginContainer/GridContainer/LanguageDropdown" to="." method="_on_language_dropdown_item_selected"]
+[connection signal="value_changed" from="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs/Gameplay/GridContainer/MusicSlider" to="." method="_on_music_slider_value_changed"]
+[connection signal="value_changed" from="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs/Gameplay/GridContainer/SFXSlider" to="." method="_on_sfx_slider_value_changed"]
+[connection signal="item_selected" from="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs/Gameplay/GridContainer/LanguageDropdown" to="." method="_on_language_dropdown_item_selected"]
+[connection signal="item_selected" from="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs/Display/GridContainer/WindowModeDropdown" to="." method="_on_window_mode_option_selected"]
+[connection signal="item_selected" from="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs/Display/GridContainer/WindowResolutionDropdown" to="." method="_on_window_resolution_option_selected"]
+[connection signal="item_selected" from="Panel/BackgroundPanel/MarginContainer/VBoxContainer/SettingsTabs/Display/GridContainer/MonitorDropdown" to="." method="_on_monitor_option_selected"]
 [connection signal="pressed" from="Panel/BackgroundPanel/MarginContainer/VBoxContainer/HBoxContainer/CloseButton" to="." method="_on_close_button_pressed"]
 [connection signal="pressed" from="Panel/BackgroundPanel/MarginContainer/VBoxContainer/HBoxContainer/SaveButton" to="." method="_on_save_button_pressed"]
 [connection signal="pressed" from="Panel/BackgroundPanel/MarginContainer/VBoxContainer/HBoxContainer/QuitButton" to="." method="_on_quit_button_pressed"]


### PR DESCRIPTION
The settings dialog now has two tabs, Gameplay and Display.

I've also limited some settings by OS.
- The Display tab is disabled for mobile and web.
- The Borderless Fullscreen mode is removed on macOS.